### PR TITLE
🎨 Bouncy platform visual distinction

### DIFF
--- a/.squad/agents/cutman/history.md
+++ b/.squad/agents/cutman/history.md
@@ -245,3 +245,45 @@
 - **Menu Overlay**: ctx.fillStyle = 'rgba(10, 10, 30, 0.85)' for darkened background with game still visible
 - **Modifier Key Check**: `if (e.key === 'M' && e.shiftKey)` for Shift+M combo to avoid key conflicts
 
+### Pause Bug Deep Fix (Issue #44, PR #44)
+- **Date:** 2026-03-14
+- **Branch:** squad/fix-pause-v2-and-superjump
+- **PR:** #44
+- **What:** Resolved persistent pause menu exit bug + clarified super jump visual feedback
+- **Changes:**
+  - **Pause Fix**: Clear keys[] object on pause entry/exit (lines 860, 870) to prevent stale input state
+  - **Resume Feedback**: Green particle burst (20 particles) on unpause for visual confirmation
+  - **Boost Balance**: Reduced boost power-up multiplier from 2.5x to 1.8x for better gameplay balance
+  - **Visual Clarity**: Added floating text feedback ('BOOST!' red, '2X BOUNCE!' green) on activation
+  - **Text Animation**: Feedback text fades and floats upward over 40 frames with shadow glow
+  - **Particle Polish**: Increased particles (20 vs 8) when boost + bouncy combine
+  - **New State Variable**: Added `feedbackText = { text, x, y, color, timer }` for floating text system
+
+### Architecture Decisions - Pause v2 & Super Jump
+- **Input State Management**: keys[] object can carry stale state across pause/resume cycles — must be explicitly cleared
+- **Visual Feedback Priority**: User confusion about intentional mechanics (boost, bouncy) indicates insufficient visual feedback, not bugs
+- **Multiplier Balancing**: 2.5x boost * 2x bouncy = 5x total velocity was excessive — reduced to 1.8x * 2x = 3.6x for better feel
+- **Feedback Text System**: Floating text with fade-out and upward motion provides non-intrusive gameplay feedback
+- **Particle Density**: Variable particle count (8 normal, 20 boosted) reinforces power difference visually
+
+### Code Patterns - Pause v2 & Super Jump
+- **State Clearing**: `keys = {}` on pause/resume prevents arrow key stickiness and input bugs
+- **Feedback Object**: `feedbackText = { text, x, y, color, timer }` updated in game loop, rendered with fade alpha
+- **Text Animation**: `feedbackText.y -= 0.5` per frame floats text upward, `alpha = Math.min(timer / 20, 1)` for fade
+- **Shadow Glow**: `ctx.shadowColor = color; ctx.shadowBlur = 10` makes text pop against varied backgrounds
+- **Conditional Particles**: `spawnParticles(x, y, color, boostMul > 1 ? 20 : 8)` adjusts intensity based on power-up state
+- **Feedback Placement**: `feedbackText = { ..., y: p.y }` at platform collision point (not ball position) for clarity
+
+### Key File Paths - Pause v2
+- **game.js** (line 32): Added feedbackText state variable
+- **game.js** (lines 860, 870): Clear keys[] on pause entry/resume
+- **game.js** (lines 1998-2018): Boost multiplier reduction + feedback text creation
+- **game.js** (lines 2121-2127): Feedback text timer update + upward float animation
+- **game.js** (lines 2283-2295): Feedback text rendering with fade + shadow glow
+
+### User Feedback Learnings
+- **Pause Bug Persistence**: PR #43 had correct logic, but the bug STILL existed for user — root cause was keys[] stale state, not event handler flow
+- **Intentional vs Bug**: User reported "super jumps" as a potential bug — actual issue was lack of visual clarity for intentional mechanics (boost + bouncy combo)
+- **Balance vs Clarity**: When users question intended mechanics, consider BOTH visual feedback AND numerical balance — reduced 2.5x to 1.8x AND added text feedback
+- **Deep Investigation Required**: When a "fixed" bug reappears, assume the fix addressed a symptom, not the root cause — trace ALL state flows, not just event handlers
+

--- a/game.js
+++ b/game.js
@@ -2000,11 +2000,11 @@ function update() {
         if (p.type === 'bouncy') {
           ball.vy = baseVy * 2 * boostMul;
           sfxBouncy();
-          spawnParticles(ball.x, p.y, '#00ff88', boostMul > 1 ? 20 : 8); // More particles if boosted
+          spawnParticles(ball.x, p.y, '#00FF7F', boostMul > 1 ? 20 : 8); // More particles if boosted
           // Extra visual feedback for bouncy platforms
           if (boostMul === 1) {
             // Non-boosted bouncy: show "2X BOUNCE!" text
-            feedbackText = { text: '2X BOUNCE!', x: ball.x, y: p.y, color: '#00ff88', timer: 40 };
+            feedbackText = { text: '2X BOUNCE!', x: ball.x, y: p.y, color: '#00FF7F', timer: 40 };
           }
         } else if (p.type === 'breakable') {
           ball.vy = baseVy * boostMul;
@@ -2199,7 +2199,7 @@ function draw() {
     switch (p.type) {
       case 'bouncy':
         p.pulse += 0.06;
-        c1 = '#00ff88'; c2 = '#00cc66';
+        c1 = '#00FF7F'; c2 = '#00D060'; // Bright spring green
         break;
       case 'breakable':
         c1 = '#ff8c00'; c2 = '#cc6600';
@@ -2218,10 +2218,28 @@ function draw() {
     pg.addColorStop(0, c1); pg.addColorStop(1, c2);
     ctx.fillStyle = pg;
     // Bouncy platforms pulse in size
-    const scaleW = p.type === 'bouncy' ? 1 + Math.sin(p.pulse) * 0.03 : 1;
+    const scaleW = p.type === 'bouncy' ? 1 + Math.sin(p.pulse) * 0.05 : 1;
     const drawX = p.x - (p.w * scaleW - p.w) / 2;
     roundRect(ctx, drawX, p.y, p.w * scaleW, p.h, 3);
     ctx.fill();
+    // Bouncy spring indicator
+    if (p.type === 'bouncy') {
+      ctx.strokeStyle = '#FFFF00'; // Bright yellow spring
+      ctx.lineWidth = 2;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      const springY = p.y + 3;
+      const springSteps = 5;
+      const stepW = p.w / springSteps;
+      let direction = 1;
+      for (let i = 0; i <= springSteps; i++) {
+        const x = p.x + i * stepW;
+        const offsetY = direction * 3;
+        ctx.lineTo(x, springY + offsetY);
+        direction *= -1;
+      }
+      ctx.stroke();
+    }
     // Breakable crack lines
     if (p.type === 'breakable') {
       ctx.strokeStyle = '#553300';


### PR DESCRIPTION
## What
Makes bouncy platforms visually distinct so players understand the super bounce mechanic.

## Why
User feedback: bouncy platforms look too similar to normal ones, causing confusion when super jumps happen.

## Changes
- Bouncy platforms now use bright spring green (#00FF7F) instead of teal
- Added yellow zigzag 'spring' indicator on top of platform
- Increased pulse wobble amplitude (0.03 → 0.05) for more visible animation
- Updated particle effects and feedback text to match new color scheme
- Platform is now unmistakable and clearly communicates '2X bounce power'